### PR TITLE
Rename user.exklusive_pubkeys to exclusive_pubkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![collection l3d.git](https://ansible.l3d.space/svg/l3d.users_ansible-collection_collection.svg)](https://galaxy.ansible.com/ui/repo/published/l3d/users/)
 [![Maintainance](https://ansible.l3d.space/svg/l3d.users_maintainance_collection.svg)](https://ansible.l3d.space/#l3d.users)
 [![License](https://ansible.l3d.space/svg/l3d.users_license_collection.svg)](LICENSE)
- 
+
  Ansible Collection l3d.users
 ===============================
 Ansible collection for managing users, groups, SSH keys and more.
@@ -71,7 +71,7 @@ The Option of these directory-variables are the following.
 | ``admin_ansible_login`` | ``true`` | - | if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``admin_root_login`` | ``true`` | - | if ``admin: true`` and ``l3d_users__set_root_ssh_keys: true`` your ssh keys will be added to root |
 | ``pubkeys`` | string or lookup | - | see examples |
-| ``exklusive_pubkeys`` | ``true`` | - | delete all undefined ssh keys |
+| ``exclusive_pubkeys`` | ``true`` | - | delete all undefined ssh keys |
 | ``password`` | password hash | - | See [official FAQ](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module) |
 | ``bashrc`` | list | - | adding additional content to l3d.users.dotfiles to .bashrc |
 | ``groups`` | list | - | Additional groups for your user |

--- a/roles/admin/README.md
+++ b/roles/admin/README.md
@@ -25,7 +25,7 @@ The Option of these directory-variables are the following.
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - |if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``pubkeys`` | string or lookup | - | see examples |
-| ``exklusive_pubkeys`` | ``true`` | - | delete all undefined ssh keys |
+| ``exclusive_pubkeys`` | ``true`` | - | delete all undefined ssh keys |
 | ``password`` | password hash | - | See [official FAQ](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module) |
 | ``groups`` | list | - | Additional groups for your user |
 | ``remove`` | ``false`` | - | completly remove user if ``state: absent`` |

--- a/roles/admin/defaults/main.yml
+++ b/roles/admin/defaults/main.yml
@@ -9,7 +9,7 @@ l3d_users__default_users: []
 #       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPvvXN33GwkTF4ZOwPgF21Un4R2z9hWUuQt1qIfzQyhC
 #       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAG65EdcM+JLv0gnzT9LcqVU47Pkw0SqiIg7XipXENi8
 #       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJz7zEvUVgJJJsIgfG3izsqYcM22IaKz4jGVUbNRL2PX
-#    exklusive_pubkeys: true
+#    exclusive_pubkeys: true
 #    password: "$Password_hash"
 #    admin: true
 #    admin_commands: 'ALL'
@@ -20,7 +20,7 @@ l3d_users__default_users: []
 #    shell: '/bin/zsh'
 #    admin: false
 #    pubkeys: "{{ lookup('url', 'https://github.com/do1jlr.keys', split_lines=False) }}"
-#    exklusive_pubkeys: false
+#    exclusive_pubkeys: false
 
 l3d_users__local_users: []
 #  - name: 'charlie'

--- a/roles/dotfiles/README.md
+++ b/roles/dotfiles/README.md
@@ -25,7 +25,7 @@ The Option of these directory-variables are the following.
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - |if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``pubkeys`` | string or lookup | - | see examples |
-| ``exklusive_pubkeys`` | ``true`` | - | delete all undefined ssh keys |
+| ``exclusive_pubkeys`` | ``true`` | - | delete all undefined ssh keys |
 | ``password`` | password hash | - | See [official FAQ](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module) |
 | ``bashrc`` | list | - | adding additional content to l3d.users.dotfiles to .bashrc |
 | ``groups`` | list | - | Additional groups for your user |

--- a/roles/dotfiles/defaults/main.yml
+++ b/roles/dotfiles/defaults/main.yml
@@ -9,7 +9,7 @@ l3d_users__default_users: []
 #       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPvvXN33GwkTF4ZOwPgF21Un4R2z9hWUuQt1qIfzQyhC
 #       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAG65EdcM+JLv0gnzT9LcqVU47Pkw0SqiIg7XipXENi8
 #       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJz7zEvUVgJJJsIgfG3izsqYcM22IaKz4jGVUbNRL2PX
-#    exklusive_pubkeys: true
+#    exclusive_pubkeys: true
 #    password: "$Password_hash"
 #    admin: true
 #    admin_commands: 'ALL'
@@ -22,7 +22,7 @@ l3d_users__default_users: []
 #    shell: '/bin/zsh'
 #    admin: false
 #    pubkeys: "{{ lookup('url', 'https://github.com/do1jlr.keys', split_lines=False) }}"
-#    exklusive_pubkeys: false
+#    exclusive_pubkeys: false
 
 l3d_users__local_users: []
 #  - name: 'charlie'

--- a/roles/sshd/README.md
+++ b/roles/sshd/README.md
@@ -25,7 +25,7 @@ The Option of these directory-variables are the following.
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - |if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``pubkeys`` | string or lookup | - | see examples |
-| ``exklusive_pubkeys`` | ``true`` | - | delete all undefined ssh keys |
+| ``exclusive_pubkeys`` | ``true`` | - | delete all undefined ssh keys |
 | ``password`` | password hash | - | See [official FAQ](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module) |
 | ``groups`` | list | - | Additional groups for your user |
 | ``remove`` | ``false`` | - | completly remove user if ``state: absent`` |

--- a/roles/sshd/defaults/main.yml
+++ b/roles/sshd/defaults/main.yml
@@ -9,7 +9,7 @@ l3d_users__default_users: []
 #       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPvvXN33GwkTF4ZOwPgF21Un4R2z9hWUuQt1qIfzQyhC
 #       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAG65EdcM+JLv0gnzT9LcqVU47Pkw0SqiIg7XipXENi8
 #       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJz7zEvUVgJJJsIgfG3izsqYcM22IaKz4jGVUbNRL2PX
-#    exklusive_pubkeys: true
+#    exclusive_pubkeys: true
 #    password: "$Password_hash"
 #    admin: true
 #    admin_commands: 'ALL'
@@ -20,7 +20,7 @@ l3d_users__default_users: []
 #    shell: '/bin/zsh'
 #    admin: false
 #    pubkeys: "{{ lookup('url', 'https://github.com/do1jlr.keys', split_lines=False) }}"
-#    exklusive_pubkeys: false
+#    exclusive_pubkeys: false
 
 l3d_users__local_users: []
 #  - name: 'charlie'

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -29,7 +29,7 @@ The Option of these directory-variables are the following.
 | ``admin_ansible_login`` | ``true`` | - | if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``admin_root_login`` | ``true`` | - | if ``admin: true`` and ``l3d_users__set_root_ssh_keys: true`` your ssh keys will be added to root |
 | ``pubkeys`` | string or lookup | - | see examples |
-| ``exklusive_pubkeys`` | ``true`` | - | delete all undefined ssh keys |
+| ``exclusive_pubkeys`` | ``true`` | - | delete all undefined ssh keys |
 | ``password`` | password hash | - | See [official FAQ](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module) |
 | ``groups`` | list | - | Additional groups for your user |
 | ``remove`` | ``false`` | - | completly remove user if ``state: absent`` |
@@ -65,7 +65,7 @@ The Option of these directory-variables are the following.
           ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPvvXN33GwkTF4ZOwPgF21Un4R2z9hWUuQt1qIfzQyhC
           ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAG65EdcM+JLv0gnzT9LcqVU47Pkw0SqiIg7XipXENi8
           ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJz7zEvUVgJJJsIgfG3izsqYcM22IaKz4jGVUbNRL2PX
-        exklusive_pubkeys: true
+        exclusive_pubkeys: true
       - name: 'bob'
         state: 'present'
         admin: false

--- a/roles/user/defaults/main.yml
+++ b/roles/user/defaults/main.yml
@@ -9,7 +9,7 @@ l3d_users__default_users: []
 #       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPvvXN33GwkTF4ZOwPgF21Un4R2z9hWUuQt1qIfzQyhC
 #       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAG65EdcM+JLv0gnzT9LcqVU47Pkw0SqiIg7XipXENi8
 #       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJz7zEvUVgJJJsIgfG3izsqYcM22IaKz4jGVUbNRL2PX
-#    exklusive_pubkeys: true
+#    exclusive_pubkeys: true
 #    password: "$Password_hash"
 #    admin: true
 #    admin_commands: 'ALL'
@@ -21,7 +21,7 @@ l3d_users__default_users: []
 #    shell: '/bin/zsh'
 #    admin: false
 #    pubkeys: "{{ lookup('url', 'https://github.com/do1jlr.keys', split_lines=False) }}"
-#    exklusive_pubkeys: false
+#    exclusive_pubkeys: false
 
 l3d_users__local_users: []
 #  - name: 'charlie'

--- a/roles/user/tasks/pubkeys.yml
+++ b/roles/user/tasks/pubkeys.yml
@@ -5,7 +5,7 @@
     user: "{{ user.name }}"
     state: 'present'
     key: "{{ user.pubkeys | default() }}"
-    exclusive: "{{ user.exklusive_pubkeys | default(true) }}"
+    exclusive: "{{ user.exclusive_pubkeys | user.exklusive_pubkeys | default(true) }}"
   loop: "{{ _l3d_users__merged_users }}"
   loop_control:
     label: "user={{ user.name }}"


### PR DESCRIPTION
Thanks for your module. I noticed this typo in the configuration variable for exclusive_pubkeys. This PR fixes that.

For backwards compatibility, the variable name user.exklusive_pubkeys if present in configuration can still be used.

