### PR TITLE
Fix: pubkeys variable template error

### DIFF
--- a/roles/user/tasks/pubkeys.yml
+++ b/roles/user/tasks/pubkeys.yml
@@ -5,7 +5,7 @@
     user: "{{ user.name }}"
     state: 'present'
     key: "{{ user.pubkeys | default() }}"
-    exclusive: "{{ user.exclusive_pubkeys | user.exklusive_pubkeys | default(true) }}"
+    exclusive: "{{ user.exclusive_pubkeys | default(user.exklusive_pubkeys | default(true)) }}"
   loop: "{{ _l3d_users__merged_users }}"
   loop_control:
     label: "user={{ user.name }}"


### PR DESCRIPTION
This fixes an error I introduced in 0e2b1a0ad40bb0b4c2796a4b8622aab4863d1e4d which you kindly merged and published on Ansible Galaxy but also _broke the module_.

I'm new to the ansible ecosystem. I wanted to use 'boolean logic' for the detection of the variable, but that's not how it works. This patch corrects the issue. Without it, trying to configure pubkeys fails with:

> fatal: [docker-registry]: FAILED! => {"msg": "template error while templating string: Could not load \"user.exklusive_pubkeys\": 'invalid plugin name: user.exklusive_pubkeys'. String: {{ user.exclusive_pubkeys | user.exklusive_pubkeys | default(true) }}. Could not load \"user.exklusive_pubkeys\": 'invalid plugin name: user.exklusive_pubkeys'"}

I _thought_ I tested my original PR before I sent it to you but `ansible-galaxy install` works differently than I thought :-(

This time around, I did make sure to actually have tested the change I sent in!