### PR TITLE
Add runas for sudoing as other users to ansible and local_users

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The Option of these directory-variables are the following.
 | ``home`` | *string* | - | Optionally set the user's home directory |
 | ``admin`` | ``false`` | - | enable it to give the user superpowers |
 | ``admin_commands`` | *string or list* | - | Commands that are allows to be run as admin, eg. 'ALL' or specific script |
+| ``admin_runas`` | *string* | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted) user may only sudo as implied user `root` |
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - | if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``admin_root_login`` | ``true`` | - | if ``admin: true`` and ``l3d_users__set_root_ssh_keys: true`` your ssh keys will be added to root |
@@ -90,6 +91,7 @@ There is also the ``l3d_users__ssh_login`` variable which only supports ``name``
 | ``l3d_users__root_ssh_keys`` | | Additional SSH Keys for root User |
 | ``l3d_users__ansible_user_password`` | | Set optional Password for Ansible User, see [official FAQ](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module) |
 | ``l3d_users__ansible_user_command`` | ``ALL`` | Commans with superpower for ansible user |
+  ``l3d_users__ansible_user_runas`` | ``ALL`` | Users that ansible can run as (needed for become_user in tasks)
 | ``l3d_users__ansible_user_nopassword`` | ``true`` | Allow superpowers without password for ansible user |
 | ``l3d_users__limit_login`` | ``true`` | Only allow SSH login for specified users |
 | ``l3d_users__additional_groups`` | ``[]`` | Optionally create some groups |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ There is also the ``l3d_users__ssh_login`` variable which only supports ``name``
 | ``l3d_users__root_ssh_keys`` | | Additional SSH Keys for root User |
 | ``l3d_users__ansible_user_password`` | | Set optional Password for Ansible User, see [official FAQ](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module) |
 | ``l3d_users__ansible_user_command`` | ``ALL`` | Commans with superpower for ansible user |
-  ``l3d_users__ansible_user_runas`` | ``ALL`` | Users that ansible can run as (needed for become_user in tasks)
+|  ``l3d_users__ansible_user_runas`` | ``ALL`` | Users that ansible can run as (needed for become_user in tasks) |
 | ``l3d_users__ansible_user_nopassword`` | ``true`` | Allow superpowers without password for ansible user |
 | ``l3d_users__limit_login`` | ``true`` | Only allow SSH login for specified users |
 | ``l3d_users__additional_groups`` | ``[]`` | Optionally create some groups |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The Option of these directory-variables are the following.
 | ``home`` | *string* | - | Optionally set the user's home directory |
 | ``admin`` | ``false`` | - | enable it to give the user superpowers |
 | ``admin_commands`` | *string or list* | - | Commands that are allows to be run as admin, eg. 'ALL' or specific script |
-| ``admin_runas`` | *string* | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted) user may only sudo as implied user `root` |
+| ``admin_runas`` | *string* | - | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted user may only sudo as implied user `root`) |
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - | if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``admin_root_login`` | ``true`` | - | if ``admin: true`` and ``l3d_users__set_root_ssh_keys: true`` your ssh keys will be added to root |

--- a/roles/admin/README.md
+++ b/roles/admin/README.md
@@ -22,7 +22,7 @@ The Option of these directory-variables are the following.
 | ``create_home`` | ``true`` | - | create a user home *(needed to store ssh keys)* |
 | ``admin``  | ``false`` | - | enable it to give the user superpowers |
 | ``admin_commands`` | *string or list* | - | Commands that are allows to be run as admin, eg. 'ALL' or specific script |
-| ``admin_runas`` | *string* | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted) user may only sudo as implied user `root` |
+| ``admin_runas`` | *string* | - | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted user may only sudo as implied user `root`) |
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - |if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``pubkeys`` | string or lookup | - | see examples |
@@ -38,7 +38,7 @@ The Option of these directory-variables are the following.
 | ``l3d_users__create_ansible`` | ``true`` | Create an Ansible User |
 | ``l3d_users__ansible_user_state`` | ``present`` | Ansible user state |
 | ``l3d_users__ansible_user_command`` | ``ALL`` | Commans with superpower for ansible user |
-  ``l3d_users__ansible_user_runas`` | ``ALL`` | Users that ansible can run as (needed for become_user in tasks)
+  ``l3d_users__ansible_user_runas`` | ``ALL`` | Users that ansible can run as (needed for become_user in tasks) |
 | ``l3d_users__ansible_user_nopassword`` | ``true`` | Allow superpowers without password for ansible user |
 | ``submodules_versioncheck`` | ``false`` | Optionaly enable simple versionscheck of this role |
 

--- a/roles/admin/README.md
+++ b/roles/admin/README.md
@@ -22,6 +22,7 @@ The Option of these directory-variables are the following.
 | ``create_home`` | ``true`` | - | create a user home *(needed to store ssh keys)* |
 | ``admin``  | ``false`` | - | enable it to give the user superpowers |
 | ``admin_commands`` | *string or list* | - | Commands that are allows to be run as admin, eg. 'ALL' or specific script |
+| ``admin_runas`` | *string* | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted) user may only sudo as implied user `root` |
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - |if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``pubkeys`` | string or lookup | - | see examples |
@@ -37,6 +38,7 @@ The Option of these directory-variables are the following.
 | ``l3d_users__create_ansible`` | ``true`` | Create an Ansible User |
 | ``l3d_users__ansible_user_state`` | ``present`` | Ansible user state |
 | ``l3d_users__ansible_user_command`` | ``ALL`` | Commans with superpower for ansible user |
+  ``l3d_users__ansible_user_runas`` | ``ALL`` | Users that ansible can run as (needed for become_user in tasks)
 | ``l3d_users__ansible_user_nopassword`` | ``true`` | Allow superpowers without password for ansible user |
 | ``submodules_versioncheck`` | ``false`` | Optionaly enable simple versionscheck of this role |
 
@@ -53,6 +55,7 @@ The Option of these directory-variables are the following.
         state: 'present'
         admin: true
         admin_commands: 'ALL'
+        admin_runas: 'ALL'
         admin_nopassword: false
         pubkeys: "{{ lookup('url', 'https://github.com/do1jlr.keys', split_lines=False) }}"
       - name: 'bob'

--- a/roles/admin/README.md
+++ b/roles/admin/README.md
@@ -38,7 +38,7 @@ The Option of these directory-variables are the following.
 | ``l3d_users__create_ansible`` | ``true`` | Create an Ansible User |
 | ``l3d_users__ansible_user_state`` | ``present`` | Ansible user state |
 | ``l3d_users__ansible_user_command`` | ``ALL`` | Commans with superpower for ansible user |
-  ``l3d_users__ansible_user_runas`` | ``ALL`` | Users that ansible can run as (needed for become_user in tasks) |
+|  ``l3d_users__ansible_user_runas`` | ``ALL`` | Users that ansible can run as (needed for become_user in tasks) |
 | ``l3d_users__ansible_user_nopassword`` | ``true`` | Allow superpowers without password for ansible user |
 | ``submodules_versioncheck`` | ``false`` | Optionaly enable simple versionscheck of this role |
 

--- a/roles/admin/defaults/main.yml
+++ b/roles/admin/defaults/main.yml
@@ -13,6 +13,7 @@ l3d_users__default_users: []
 #    password: "$Password_hash"
 #    admin: true
 #    admin_commands: 'ALL'
+#    admin_runas: 'ALL'
 #    admin_nopassword: false
 #    admin_ansible_login: true
 #  - name: 'bob'
@@ -31,6 +32,7 @@ l3d_users__local_users: []
 l3d_users__create_ansible: true
 l3d_users__ansible_user_state: 'present'
 l3d_users__ansible_user_command: 'ALL'
+l3d_users__ansible_user_runas: 'ALL'
 l3d_users__ansible_user_nopassword: true
 
 # run simple versionscheck

--- a/roles/admin/tasks/user_ansible.yml
+++ b/roles/admin/tasks/user_ansible.yml
@@ -6,5 +6,6 @@
     commands: "{{ l3d_users__ansible_user_command }}"
     nopassword: "{{ l3d_users__ansible_user_nopassword | bool }}"
     user: 'ansible'
+    runas: "{{ l3d_users__ansible_user_runas | default('ALL')}}"
     state: "{{ l3d_users__ansible_user_state | ternary('present', 'absent') }}"
     validation: 'required'

--- a/roles/admin/tasks/users.yml
+++ b/roles/admin/tasks/users.yml
@@ -6,6 +6,7 @@
     user: "{{ user.name }}"
     state: 'present'
     commands: "{{ user.admin_commands | default('ALL') }}"
+    runas: "{{ user.admin_runas | default(omit) }}"
     nopassword: "{{ user.admin_nopassword | default(false) }}"
   loop: "{{ _l3d_users__merged_users }}"
   loop_control:

--- a/roles/dotfiles/README.md
+++ b/roles/dotfiles/README.md
@@ -22,7 +22,7 @@ The Option of these directory-variables are the following.
 | ``create_home`` | ``true`` | - | create a user home *(needed to store ssh keys)* |
 | ``admin`` | ``false`` | - | enable it to give the user superpowers |
 | ``admin_commands`` | *string or list* | - | Commands that are allows to be run as admin, eg. 'ALL' or specific script |
-| ``admin_runas`` | *string* | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted) user may only sudo as implied user `root` |
+| ``admin_runas`` | *string* | - | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted user may only sudo as implied user `root`) |
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - |if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``pubkeys`` | string or lookup | - | see examples |

--- a/roles/dotfiles/README.md
+++ b/roles/dotfiles/README.md
@@ -22,6 +22,7 @@ The Option of these directory-variables are the following.
 | ``create_home`` | ``true`` | - | create a user home *(needed to store ssh keys)* |
 | ``admin`` | ``false`` | - | enable it to give the user superpowers |
 | ``admin_commands`` | *string or list* | - | Commands that are allows to be run as admin, eg. 'ALL' or specific script |
+| ``admin_runas`` | *string* | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted) user may only sudo as implied user `root` |
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - |if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``pubkeys`` | string or lookup | - | see examples |

--- a/roles/dotfiles/defaults/main.yml
+++ b/roles/dotfiles/defaults/main.yml
@@ -13,6 +13,7 @@ l3d_users__default_users: []
 #    password: "$Password_hash"
 #    admin: true
 #    admin_commands: 'ALL'
+#    admin_runas: 'ALL'
 #    admin_nopassword: false
 #    admin_ansible_login: true
 #    bashrc:

--- a/roles/sshd/README.md
+++ b/roles/sshd/README.md
@@ -22,7 +22,7 @@ The Option of these directory-variables are the following.
 | ``create_home`` | ``true`` | - | create a user home *(needed to store ssh keys)* |
 | ``admin`` | ``false`` | - | enable it to give the user superpowers |
 | ``admin_commands`` | *string or list* | - | Commands that are allows to be run as admin, eg. 'ALL' or specific script |
-| ``admin_runas`` | *string* | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted) user may only sudo as implied user `root` |
+| ``admin_runas`` | *string* | - | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted user may only sudo as implied user `root`) |
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - |if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``pubkeys`` | string or lookup | - | see examples |

--- a/roles/sshd/README.md
+++ b/roles/sshd/README.md
@@ -22,6 +22,7 @@ The Option of these directory-variables are the following.
 | ``create_home`` | ``true`` | - | create a user home *(needed to store ssh keys)* |
 | ``admin`` | ``false`` | - | enable it to give the user superpowers |
 | ``admin_commands`` | *string or list* | - | Commands that are allows to be run as admin, eg. 'ALL' or specific script |
+| ``admin_runas`` | *string* | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted) user may only sudo as implied user `root` |
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - |if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``pubkeys`` | string or lookup | - | see examples |

--- a/roles/sshd/defaults/main.yml
+++ b/roles/sshd/defaults/main.yml
@@ -13,6 +13,7 @@ l3d_users__default_users: []
 #    password: "$Password_hash"
 #    admin: true
 #    admin_commands: 'ALL'
+#    admin_runas: 'ALL'
 #    admin_nopassword: false
 #    admin_ansible_login: true
 #  - name: 'bob'

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -25,7 +25,7 @@ The Option of these directory-variables are the following.
 | ``home`` | *string* | - | Optionally set the user's home directory |
 | ``admin`` | ``false`` | - | enable it to give the user superpowers |
 | ``admin_commands`` | *string or list* | - | Commands that are allows to be run as admin, eg. 'ALL' or specific script |
-| ``admin_runas`` | *string* | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted) user may only sudo as implied user `root` |
+| ``admin_runas`` | *string* | - | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted user may only sudo as implied user `root`) |
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - | if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``admin_root_login`` | ``true`` | - | if ``admin: true`` and ``l3d_users__set_root_ssh_keys: true`` your ssh keys will be added to root |

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -25,6 +25,7 @@ The Option of these directory-variables are the following.
 | ``home`` | *string* | - | Optionally set the user's home directory |
 | ``admin`` | ``false`` | - | enable it to give the user superpowers |
 | ``admin_commands`` | *string or list* | - | Commands that are allows to be run as admin, eg. 'ALL' or specific script |
+| ``admin_runas`` | *string* | Users that this user can run as (allows sudo -u <user> by this user). "ALL", or ``comma separated list as a string``. Default `null` (omitted) user may only sudo as implied user `root` |
 | ``admin_nopassword`` | ``false`` | - | Need no Password for sudo |
 | ``admin_ansible_login`` | ``true`` | - | if ``admin: true`` and ``l3d_users__create_ansible: true`` your ssh keys will be added to ansible user |
 | ``admin_root_login`` | ``true`` | - | if ``admin: true`` and ``l3d_users__set_root_ssh_keys: true`` your ssh keys will be added to root |

--- a/roles/user/defaults/main.yml
+++ b/roles/user/defaults/main.yml
@@ -13,6 +13,7 @@ l3d_users__default_users: []
 #    password: "$Password_hash"
 #    admin: true
 #    admin_commands: 'ALL'
+#    admin_runas: 'ALL'
 #    admin_nopassword: false
 #    admin_ansible_login: true
 #    groups: ['admin', 'foo', 'bar']


### PR DESCRIPTION
* Default for ansible is "ALL"
* Default for users is null (which is what the previous code did)
* This lets users control the runas parameter in the sudoers ansible module